### PR TITLE
Hash in parallel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/benwr/bromberg_sl2"
 categories = ["cryptography", "algorithms", "no-std"]
 keywords = ["hashing", "sl2", "homomorphic", "monoidal", "tillich-zemor"]
 
+[features]
+default = ["std"]
+std = ["rayon"]
+
 [profile.release]
 lto = true
 opt-level = 3
@@ -22,6 +26,7 @@ codegen-units = 1
 [dependencies]
 seq-macro = "^0.2"
 lazy_static = "^1.4"
+rayon = { version = "1.5.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/benches/compare_with_sha.rs
+++ b/benches/compare_with_sha.rs
@@ -7,21 +7,31 @@ use sha3::{Digest, Sha3_512};
 // This isjust stolen straight from the Criterion documentation
 fn from_elem(c: &mut Criterion) {
     static KB: usize = 1024;
+    let sizes = [KB, 2 * KB, 4 * KB, 8 * KB, 16 * KB, 4096 * KB];
 
     let mut group = c.benchmark_group("byte_hashing");
-    for size in [KB, 2 * KB, 4 * KB, 8 * KB, 16 * KB].iter() {
+    for size in sizes.iter() {
         group.throughput(Throughput::Bytes(*size as u64));
         group.bench_with_input(BenchmarkId::new("bromberg", size), size, |b, &size| {
             b.iter(|| black_box(iter::repeat(5u8).take(size).collect::<Vec<u8>>().bromberg_hash()));
         });
     }
-    for size in [KB, 2 * KB, 4 * KB, 8 * KB, 16 * KB].iter() {
+    for size in sizes.iter() {
         group.throughput(Throughput::Bytes(*size as u64));
         group.bench_with_input(BenchmarkId::new("bromberg_strict", size), size, |b, &size| {
             b.iter(|| black_box(hash_strict(&iter::repeat(5u8).take(size).collect::<Vec<u8>>())));
         });
     }
-    for size in [KB, 2 * KB, 4 * KB, 8 * KB, 16 * KB].iter() {
+    #[cfg(feature = "std")]
+    {
+        for size in sizes.iter() {
+            group.throughput(Throughput::Bytes(*size as u64));
+            group.bench_with_input(BenchmarkId::new("bromberg_par", size), size, |b, &size| {
+                b.iter(|| black_box(hash_par(&iter::repeat(5u8).take(size).collect::<Vec<u8>>())));
+            });
+        }
+    }
+    for size in sizes.iter() {
         group.throughput(Throughput::Bytes(*size as u64));
         group.bench_with_input(BenchmarkId::new("sha", size), size, |b, &size| {
             b.iter(|| {

--- a/src/hash_matrix.rs
+++ b/src/hash_matrix.rs
@@ -283,4 +283,13 @@ mod tests {
             ares != bres || a == b
         }
     }
+
+    #[cfg(feature = "std")]
+    quickcheck! {
+        fn par_equiv(a: Vec<u8>) -> bool {
+            let h0 = hash(&a);
+            let h1 = hash_par(&a);
+            h0 == h1
+        }
+    }
 }


### PR DESCRIPTION
Great crate! :smile: 

I think you can exploit the monoidal properties of this hashing function to make it even faster than `sha` (on long enough inputs).

This does rely on `rayon` and therefore `std`, but I see the crate advertised `no_std` so I put `std` behind a feature.

![byte_hashing_violin](https://user-images.githubusercontent.com/3369034/142724221-4d09584a-c8da-4aa9-8c47-6e20ed945ef7.png)

<details>
  <summary>On my modest 4 core CPU</summary>

```
❯ lscpu
Architecture:                    x86_64
CPU op-mode(s):                  32-bit, 64-bit
Byte Order:                      Little Endian
Address sizes:                   39 bits physical, 48 bits virtual
CPU(s):                          4
On-line CPU(s) list:             0-3
Thread(s) per core:              1
Core(s) per socket:              4
Socket(s):                       1
NUMA node(s):                    1
Vendor ID:                       GenuineIntel
CPU family:                      6
Model:                           158
Model name:                      Intel(R) Core(TM) i5-7600 CPU @ 3.50GHz
Stepping:                        9
CPU MHz:                         3983.006
CPU max MHz:                     4100.0000
CPU min MHz:                     800.0000
BogoMIPS:                        6999.82
Virtualization:                  VT-x
L1d cache:                       128 KiB
L1i cache:                       128 KiB
L2 cache:                        1 MiB
L3 cache:                        6 MiB
NUMA node0 CPU(s):               0-3
Vulnerability Itlb multihit:     KVM: Mitigation: Split huge pages
Vulnerability L1tf:              Mitigation; PTE Inversion; VMX conditional cache flushes, SMT disabled
Vulnerability Mds:               Mitigation; Clear CPU buffers; SMT disabled
Vulnerability Meltdown:          Mitigation; PTI
Vulnerability Spec store bypass: Mitigation; Speculative Store Bypass disabled via prctl and seccomp
Vulnerability Spectre v1:        Mitigation; usercopy/swapgs barriers and __user pointer sanitization
Vulnerability Spectre v2:        Mitigation; Full generic retpoline, IBPB conditional, IBRS_FW, STIBP disabled, RSB filling
Vulnerability Srbds:             Mitigation; Microcode
Vulnerability Tsx async abort:   Mitigation; Clear CPU buffers; SMT disabled
Flags:                           fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good no
                                 pl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16
                                 c rdrand lahf_lm abm 3dnowprefetch cpuid_fault invpcid_single pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm mpx rd
                                 seed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d
```
</details>
